### PR TITLE
Rename repostiroy name to autify-cli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     replacements:
       darwin: darwin
       linux: linux
@@ -31,8 +31,8 @@ brews:
       owner: koukikitamura
       name: homebrew-autify-cli
     folder: Formula
-    homepage: 'https://github.com/koukikitamura/autify-cli'
-    description: 'Autify client'
+    homepage: "https://github.com/koukikitamura/autify-client"
+    description: "Autify CLI client"
     license: "MIT"
     install: |
       bin.install "atf"

--- a/README.md
+++ b/README.md
@@ -1,23 +1,30 @@
-# autify-cli
+# autify-client
+
 This package provides a unified command line interface to Autify.
 
 ## Installation
+
 ### macOS
+
 ```
-brew install koukikitamura/autify-cli/autify-cli
+brew tap koukikitamura/autify-cli
+brew install autify-cli
 ```
 
 ### Linux
+
 Download TAR archive from github release page.
+
 ```
-curl -LSfs https://raw.githubusercontent.com/koukikitamura/autify-cli/main/scripts/install.sh | \
+curl -LSfs https://raw.githubusercontent.com/koukikitamura/autify-client/main/scripts/install.sh | \
   sh -s -- \
-    --git koukikitamura/autify-cli \
+    --git koukikitamura/autify-client \
     --target autify-cli_linux_x86_64 \
     --to /usr/local/bin
 ```
 
 ## Configuration
+
 Before using the autify-cli, you need to configure your credentials. You can use environment variable.
 
 ```
@@ -25,24 +32,29 @@ export AUTIFY_PERSONAL_ACCESS_TOKEN=<access token>
 ```
 
 ## Basic Commands
+
 An autify-cli command has the following structure:
+
 ```
 $ atf <command> [options]
 ```
 
 To run test plan and wait to finish, the command would be:
+
 ```
 $ atf run --project-id=999 --plan-id=999
 {"id":999,"status":"passed","duration":26251,"started_at":"2021-03-28T11:03:31.288Z","finished_at":"2021-03-28T11:03:57.54Z","created_at":"2021-03-28T11:03:04.716Z","updated_at":"2021-03-28T11:04:00.738Z","test_plan":{"id":999,"name":"main flow","created_at":"2021-03-26T08:25:12.987Z","updated_at":"2021-03-26T08:33:45.462Z"}}
 ```
 
 To fetch scenario, the command would be:
+
 ```
 $ atf scenario --project-id=999 --scenario-id=999
 {"id":999,"name":"login","created_at":"2021-03-26T07:53:20.039Z","updated_at":"2021-03-26T08:20:51.86Z"}
 ```
 
 To fetch test plan excution result, the command would be:
+
 ```
 $ atf result --project-id=999 --result-id=999
 {"id":999,"status":"waiting","duration":26621,"started_at":"2021-03-26T10:09:12.915Z","finished_at":"2021-03-26T10:09:39.537Z","created_at":"2021-03-26T10:08:54.769Z","updated_at":"2021-03-26T10:09:44.542Z","test_plan":{"id":999,"name":"main flow","created_at":"2021-03-26T08:25:12.987Z","updated_at":"2021-03-26T08:33:45.462Z"}}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/koukikitamura/autify-cli
+module github.com/koukikitamura/autify-client
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/koukikitamura/autify-cli/internal"
+	"github.com/koukikitamura/autify-client/internal"
 	"github.com/mitchellh/cli"
 	"github.com/sirupsen/logrus"
 )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Original: https://github.com/japaric/trust/blob/gh-pages/install.sh
 
 # ./install.sh \
-#   --git koukikitamura/autify-cli \
+#   --git koukikitamura/autify-client \
 #   --target autify-cli_darwin_x86_64 \
 #   --to ./usr/local/bin
 


### PR DESCRIPTION
## Description
This PR is an implementation of  https://github.com/koukikitamura/autify-client/issues/1
Rename repository name to autify-client. 

## Checklist
- [x] Release a CLI tool from Github Actions
- [x] Download  CLI tool from homebrew & TAR archive of the release page.